### PR TITLE
Adding support for the language paramter to the GoogleGeocoder3.

### DIFF
--- a/lib/geokit/geocoders.rb
+++ b/lib/geokit/geocoders.rb
@@ -602,16 +602,22 @@ module Geokit
       end
  
       # Determine the Google API url based on the google api key, or based on the client / private key for premier users
+      # Options accepts a :language param which is a two character ISO country code
       def self.geocode_url(address,options = {})
         bias_str = options[:bias] ? construct_bias_string_from_options(options[:bias]) : ''
+        language_str = options[:language] ? construct_language_string_from_options(options[:language]) : ''
         address_str = address.is_a?(GeoLoc) ? address.to_geocodeable_s : address
-
+        
         if !Geokit::Geocoders::google_client_id.nil? && !Geokit::Geocoders::google_premier_secret_key.nil?
-          url = "http://maps.googleapis.com/maps/api/geocode/json?address=#{Geokit::Inflector::url_escape(address_str)}#{bias_str}&client=#{Geokit::Geocoders::google_client_id}&sensor=false&oe=utf-8"
+          url = "http://maps.googleapis.com/maps/api/geocode/json?address=#{Geokit::Inflector::url_escape(address_str)}#{bias_str}&client=#{Geokit::Geocoders::google_client_id}&sensor=false&oe=utf-8#{language_str}"
           Geokit::Geocoders::Geocoder.sign_url(url,Geokit::Geocoders::google_premier_secret_key)
         else
-          "http://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector::url_escape(address_str)}#{bias_str}"
+          "http://maps.google.com/maps/api/geocode/json?sensor=false&address=#{Geokit::Inflector::url_escape(address_str)}#{bias_str}#{language_str}"
         end
+      end
+      
+      def self.construct_language_string_from_options(language)
+        "&language=#{language.to_s.downcase}"
       end
  
  

--- a/spec/geocoder_spec.rb
+++ b/spec/geocoder_spec.rb
@@ -67,7 +67,12 @@ describe "Geocoder" do
       expected = "http://maps.googleapis.com/maps/api/geocode/json?address=Ottawa&client=gme-cenx&sensor=false&oe=utf-8&signature=VG4njf1Yo59tnEvwPAMlgOoj4_0="
       Geokit::Geocoders::GoogleGeocoder3.geocode_url('Ottawa',{}).should == expected
     end
-    
+
+    it "should use the language parameter if given" do 
+      Geokit::Geocoders::google = 'abc123'
+      expected = "http://maps.google.com/maps/api/geocode/json?sensor=false&address=Ottawa&language=en"
+      Geokit::Geocoders::GoogleGeocoder3.geocode_url('Ottawa',{:language => 'en'}).should == expected
+    end
   end
 
   describe "sorting results" do


### PR DESCRIPTION
This allows you to pass the :language option to the GoogleGeocoder3.geocode method in order to specify which language your results are returned in. This is similar to the :bias param and is handled the same way. For example

`Geokit::Geocoders::GoogleGeocoder3.geocode("Munich, Germany")` will return the city as Munich which is English.

`Geokit::Geocoders::GoogleGeocoder3.geocode("Munich, Germany", :language => 'DE')` will return the city as Munchen which is German.
